### PR TITLE
fixes UnicodeDecodeError

### DIFF
--- a/octokit_routes/__init__.py
+++ b/octokit_routes/__init__.py
@@ -5,7 +5,7 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 
 
 def _load_json(path):
-    with open(path, "r") as f:
+    with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
 
 


### PR DESCRIPTION
when importing octokit on windows 

```python
from octokit import Octokit
```

the following error occurs

```
Traceback (most recent call last):
  File "C:\Users\user\stuff.py", line 1, in <module>
    from octokit import Octokit
  File "C:\Users\user\AppData\Local\Programs\Python\Python39\lib\site-packages\octokit\__init__.py", line 6, in <module>
    from octokit_routes import specifications
  File "C:\Users\user\AppData\Local\Programs\Python\Python39\lib\site-packages\octokit_routes\__init__.py", line 31, in <module>
    specifications = {spec.replace(".json", ""): _load_spec(spec) for spec in specs}
  File "C:\Users\user\AppData\Local\Programs\Python\Python39\lib\site-packages\octokit_routes\__init__.py", line 31, in <dictcomp>
    specifications = {spec.replace(".json", ""): _load_spec(spec) for spec in specs}
  File "C:\Users\user\AppData\Local\Programs\Python\Python39\lib\site-packages\octokit_routes\__init__.py", line 21, in _load_spec
    return _load_json(os.path.join(__location__, "routes", spec_name))
  File "C:\Users\user\AppData\Local\Programs\Python\Python39\lib\site-packages\octokit_routes\__init__.py", line 9, in _load_json
    return json.load(f)
  File "C:\Users\user\AppData\Local\Programs\Python\Python39\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
  File "C:\Users\user\AppData\Local\Programs\Python\Python39\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 6024723: character maps to <undefined>
```

This PR fixes that

closes #83 